### PR TITLE
Make method names self-documenting

### DIFF
--- a/src/chess/Bishop.java
+++ b/src/chess/Bishop.java
@@ -31,28 +31,14 @@ final class Bishop extends Piece {
 
     @Override
     boolean isActionLegal(Point start, Point end) {
-        return isEachCoordinateDeltaSame(start, end) && isBishopActionLegal(start, end)
+        return isDiagonalLine(start, end) && isBishopActionLegal(start, end)
                 && wouldNotPutAlliedKingIntoCheck(start, end);
     }
 
-    /**
-     * Checks to see if the change in x is the same as the change in y.
-     *
-     * @param start the original position
-     * @param end   the final position
-     * @return true if the change in x is the same as the change in y
-     */
-    boolean isEachCoordinateDeltaSame(Point start, Point end) {
+    boolean isDiagonalLine(Point start, Point end) {
         return Math.abs(end.y - start.y) == Math.abs(end.x - start.x);
     }
 
-    /**
-     * Bishop can capture enemy and can travel as long as nothing is in its way.
-     *
-     * @param start the original position
-     * @param end   the final position
-     * @return true if bishop action is legal
-     */
     boolean isBishopActionLegal(Point start, Point end) {
         final int min = Math.min(start.x, end.x);
         final int max = Math.max(start.x, end.x);

--- a/src/chess/Bishop.java
+++ b/src/chess/Bishop.java
@@ -21,7 +21,7 @@ final class Bishop extends Piece {
                 {0, 0, 1, 1, 0, 0},
                 {1, 1, 1, 1, 1, 1}
         };
-        getColor(pixels);
+        setPieceImage(pixels);
     }
 
     @Override
@@ -32,7 +32,7 @@ final class Bishop extends Piece {
     @Override
     boolean isActionLegal(Point start, Point end) {
         return isEachCoordinateDeltaSame(start, end) && isBishopActionLegal(start, end)
-                && wouldNotPutKingIntoCheck(start, end);
+                && wouldNotPutAlliedKingIntoCheck(start, end);
     }
 
     /**
@@ -66,6 +66,6 @@ final class Bishop extends Piece {
                 return false;
             }
         }
-        return canMoveOnto(end);
+        return canMoveToLocation(end);
     }
 }

--- a/src/chess/Chess.java
+++ b/src/chess/Chess.java
@@ -135,7 +135,7 @@ final class Chess {
         for (int i = 0; i < BOARD_SIZE; i++) {
             for (int j = 0; j < BOARD_SIZE; j++) {
                 if (board[i][j] != null) {
-                    final Color[][] image = board[i][j].getImage();
+                    final Color[][] image = board[i][j].getPieceImage();
                     setPieceColor(j * PIXELS_PER_SQUARE, i * PIXELS_PER_SQUARE, image);
                 }
             }

--- a/src/chess/Chess.java
+++ b/src/chess/Chess.java
@@ -40,8 +40,8 @@ final class Chess {
     }
 
     private Chess() {
-        configureGUI();
-        resetBoard();
+        initializeGUI();
+        setupPiecesOnBoard();
         refreshPixels();
         state = new GameState(this, isWhiteTurn);
     }
@@ -54,9 +54,6 @@ final class Chess {
         return board[point.y][point.x];
     }
 
-    /**
-     * Flips the board so that the opposite player can play with the correct orientation.
-     */
     void flipBoard() {
         isWhiteTurn = !isWhiteTurn;
         for (int i = 0; i < BOARD_SIZE / 2; i++) {
@@ -67,10 +64,7 @@ final class Chess {
         refreshPixels();
     }
 
-    /**
-     * Initializes the graphical user interface.
-     */
-    private void configureGUI() {
+    private void initializeGUI() {
         frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         frame.setResizable(false);
         frame.setLayout(new BorderLayout());
@@ -80,10 +74,7 @@ final class Chess {
         frame.setVisible(true);
     }
 
-    /**
-     * Sets up the chess pieces on the chess board.
-     */
-    private void resetBoard() {
+    private void setupPiecesOnBoard() {
         board[0][0] = new Rook(!isWhiteTurn);
         board[0][1] = new Knight(!isWhiteTurn);
         board[0][2] = new Bishop(!isWhiteTurn);
@@ -106,50 +97,34 @@ final class Chess {
         board[7][7] = new Rook(isWhiteTurn);
     }
 
-    /**
-     * Refreshes the display on the graphical user interface.
-     */
     void refreshPixels() {
-        setBackGround();
-        setPieces();
+        drawBackgroundGUI();
+        drawAllPiecesGUI();
     }
 
-    /**
-     * Sets the checkerboard pattern for the board on the graphical user interface.
-     */
-    private void setBackGround() {
+    private void drawBackgroundGUI() {
         final Color darkBrown = new Color(160, 80, 0);
         final Color lightBrown = new Color(200, 100, 0);
         for (int i = 0; i < BOARD_SIZE; i++) {
             for (int j = 0; j < BOARD_SIZE; j++) {
                 final Color usedColor = ((i + j) % 2 == 0 ^ !isWhiteTurn) ? lightBrown : darkBrown;
-                fillInSubSection(usedColor, j, i);
+                drawTileBackgroundGUI(usedColor, j, i);
             }
         }
     }
 
-    /**
-     * Adds the pieces to the chess board on the graphical user interface.
-     */
-    void setPieces() {
+    void drawAllPiecesGUI() {
         for (int i = 0; i < BOARD_SIZE; i++) {
             for (int j = 0; j < BOARD_SIZE; j++) {
                 if (board[i][j] != null) {
                     final Color[][] image = board[i][j].getPieceImage();
-                    setPieceColor(j * PIXELS_PER_SQUARE, i * PIXELS_PER_SQUARE, image);
+                    drawPiecGUI(j * PIXELS_PER_SQUARE, i * PIXELS_PER_SQUARE, image);
                 }
             }
         }
     }
 
-    /**
-     * Determines the color of the piece on the chess board.
-     *
-     * @param x     the x-coordinate
-     * @param y     the y-coordinate
-     * @param image the image of the chess piece
-     */
-    private void setPieceColor(int x, int y, Color[][] image) {
+    private void drawPiecGUI(int x, int y, Color[][] image) {
         for (int i = 1; i < PIXELS_PER_SQUARE - 1; i++) {
             for (int j = 1; j < PIXELS_PER_SQUARE - 1; j++) {
                 if (image[i - 1][j - 1] != null) {
@@ -159,14 +134,7 @@ final class Chess {
         }
     }
 
-    /**
-     * Fills in the specified square for the checkerboard pattern.
-     *
-     * @param color the color to fill in
-     * @param x     the x-coordinate
-     * @param y     the y-coordinate
-     */
-    void fillInSubSection(Color color, int x, int y) {
+    void drawTileBackgroundGUI(Color color, int x, int y) {
         for (int i = 0; i < PIXELS_PER_SQUARE; i++) {
             for (int j = 0; j < PIXELS_PER_SQUARE; j++) {
                 pixels[i + y * PIXELS_PER_SQUARE][j + x * PIXELS_PER_SQUARE] = color;

--- a/src/chess/Chess.java
+++ b/src/chess/Chess.java
@@ -156,7 +156,7 @@ final class Chess {
                     if (state != null) {
                         final int horizontalClickPosition = (e.getX()) / (getWidth() / PIXELS_PER_SQUARE);
                         final int verticalClickPosition = (e.getY()) / (getHeight() / PIXELS_PER_SQUARE);
-                        state.clicked(horizontalClickPosition, verticalClickPosition);
+                        state.handleClick(horizontalClickPosition, verticalClickPosition);
                     }
                 }
             });

--- a/src/chess/GameState.java
+++ b/src/chess/GameState.java
@@ -153,7 +153,7 @@ final class GameState {
             move(moving, from, to);
             final Point location = locateKing(isWhiteTurn);
             final King king = new King(isWhiteTurn);
-            if (!king.isCheck(location)) {
+            if (!king.isKingInCheck(location)) {
                 isWhiteTurn = !isWhiteTurn;
                 chess.flipBoard();
                 checkEndgame();
@@ -280,7 +280,7 @@ final class GameState {
      * @return true if the game is over by checkmate
      */
     private boolean isCheckmate(King king, Point point) {
-        return king.isCheck(point) && isMoveImpossible(king, point);
+        return king.isKingInCheck(point) && isMoveImpossible(king, point);
     }
 
     /**
@@ -291,7 +291,7 @@ final class GameState {
      * @return true if the game is over by stalemate
      */
     private boolean isStalemate(King king, Point point) {
-        return !king.isCheck(point) && isMoveImpossible(king, point);
+        return !king.isKingInCheck(point) && isMoveImpossible(king, point);
     }
 
     /**
@@ -318,7 +318,7 @@ final class GameState {
                             if (me.isActionLegal(start, end)) {
                                 rawMove(me, start, end);
                                 final Point kingLocation = locateKing(isWhiteTurn);
-                                final boolean isNotInCheck = !king.isCheck(kingLocation);
+                                final boolean isNotInCheck = !king.isKingInCheck(kingLocation);
                                 rawMove(me, end, start);
                                 Chess.setBoard(end, save);
                                 if (isNotInCheck) {
@@ -494,7 +494,7 @@ final class GameState {
      * @param location the location of the king in check
      */
     private void warnIfCheck(King king, Point location) {
-        if (king.isCheck(location)) {
+        if (king.isKingInCheck(location)) {
             isInCheck = true;
             final String text = Chess.resource.getString("inCheck");
             final String[] options = {Chess.resource.getString("acknowledge")};
@@ -535,8 +535,8 @@ final class GameState {
         final boolean isClearPath = hasMoved(Chess.getBoard(new Point(0, 7)))
                 && Chess.getBoard(new Point(1, 7)) == null && Chess.getBoard(new Point(2, 7)) == null
                 && Chess.getBoard(new Point(3, 7)) == null && hasMoved(Chess.getBoard(new Point(4, 7)));
-        final boolean isNotPassingThroughCheck = !king.isCheck(new Point(4, 7))
-                && !king.isCheck(new Point(3, 7)) && !king.isCheck(new Point(2, 7));
+        final boolean isNotPassingThroughCheck = !king.isKingInCheck(new Point(4, 7))
+                && !king.isKingInCheck(new Point(3, 7)) && !king.isKingInCheck(new Point(2, 7));
         return isLockedOnKing && isClearPath && isNotPassingThroughCheck;
     }
 
@@ -550,8 +550,8 @@ final class GameState {
         final boolean isLockedOnKing = from.x == 4 && from.y == 7;
         final boolean isClearPath = hasMoved(Chess.getBoard(new Point(4, 7))) && Chess.getBoard(new Point(5, 7)) == null
                 && Chess.getBoard(new Point(6, 7)) == null && hasMoved(Chess.getBoard(new Point(7, 7)));
-        final boolean isNotPassingThroughCheck = !king.isCheck(new Point(4, 7))
-                && !king.isCheck(new Point(5, 7)) && !king.isCheck(new Point(6, 7));
+        final boolean isNotPassingThroughCheck = !king.isKingInCheck(new Point(4, 7))
+                && !king.isKingInCheck(new Point(5, 7)) && !king.isKingInCheck(new Point(6, 7));
         return isLockedOnKing && isClearPath && isNotPassingThroughCheck;
     }
 

--- a/src/chess/GameState.java
+++ b/src/chess/GameState.java
@@ -117,29 +117,29 @@ final class GameState {
                     final Piece backup = Chess.getBoard(from);
                     Chess.setBoard(from, null);
                     if (moving.isActionLegal(from, checkAt)) {
-                        chess.fillInSubSection(usedColor, j, i);
+                        chess.drawTileBackgroundGUI(usedColor, j, i);
                     }
                     Chess.setBoard(from, backup);
                 } else if (moving.isActionLegal(from, checkAt)) {
-                    chess.fillInSubSection(usedColor, j, i);
+                    chess.drawTileBackgroundGUI(usedColor, j, i);
                 }
             }
         }
         if (canQueenSideCastle()) {
-            chess.fillInSubSection(isWhiteTurn ? darkGreen : lightGreen, 0, Chess.BOARD_SIZE - 1);
+            chess.drawTileBackgroundGUI(isWhiteTurn ? darkGreen : lightGreen, 0, Chess.BOARD_SIZE - 1);
         }
         if (canKingSideCastle()) {
-            chess.fillInSubSection(isWhiteTurn ? lightGreen : darkGreen, Chess.BOARD_SIZE - 1, Chess.BOARD_SIZE - 1);
+            chess.drawTileBackgroundGUI(isWhiteTurn ? lightGreen : darkGreen, Chess.BOARD_SIZE - 1, Chess.BOARD_SIZE - 1);
         }
         if (enPassant != null) {
             final boolean canCaptureEnPassant = from.y == enPassant.y + 1
                     && Math.abs(from.x - enPassant.x) == 1;
             if (canCaptureEnPassant && isEnPassantLegal(enPassant)) {
                 final Color usedColor = ((enPassant.y + enPassant.x) % 2 == 0 ^ !isWhiteTurn) ? lightGreen : darkGreen;
-                chess.fillInSubSection(usedColor, enPassant.x, enPassant.y);
+                chess.drawTileBackgroundGUI(usedColor, enPassant.x, enPassant.y);
             }
         }
-        chess.setPieces();
+        chess.drawAllPiecesGUI();
     }
 
     /**

--- a/src/chess/GameState.java
+++ b/src/chess/GameState.java
@@ -26,16 +26,10 @@ final class GameState {
         this.isWhiteTurn = isWhiteTurn;
         final String text = Chess.resource.getString("startupInformation");
         final String[] options = {Chess.resource.getString("acknowledge")};
-        customText(text, options);
+        displayDialogText(text, options);
     }
 
-    /**
-     * Handles a click event.
-     *
-     * @param x the x-coordinate of the click
-     * @param y the y-coordinate of the click
-     */
-    void clicked(int x, int y) {
+    void handleClick(int x, int y) {
         if (moving == null) {
             lockOntoPiece(new Point(x, y));
             return;
@@ -43,30 +37,23 @@ final class GameState {
         chess.refreshPixels();
         final Point to = new Point(x, y);
         if (isInCheck) {
-            doMoveInCheck(to);
+            doMoveInCheckIfLegal(to);
         } else if (castleIfPossible(to)) {
             isWhiteTurn = !isWhiteTurn;
             chess.flipBoard();
             enPassant = null;
             enPassantHistory.add(null);
-        } else if (isEnPassantLegal(to)) {
+        } else if (canPerformEnPassant(to)) {
             doEnPassant();
         } else if (moving.isActionLegal(from, to)) {
-            checkEnPassant(to);
+            recordEnPassantHistory(to);
             doMove(to);
         }
         moving = null;
         from = null;
     }
 
-    /**
-     * Determines the location of the allied king.
-     *
-     * @param isWhiteTurn the color of the allied king
-     * @return location of the allied king
-     * @throws IllegalStateException if there is no allied king or more than one allied king
-     */
-    static Point locateKing(boolean isWhiteTurn) {
+    static Point locateAlliedKing(boolean isWhiteTurn) {
         Point king = null;
         for (int i = 0; i < Chess.BOARD_SIZE; i++) {
             for (int j = 0; j < Chess.BOARD_SIZE; j++) {
@@ -86,27 +73,19 @@ final class GameState {
         throw new IllegalStateException("No King!");
     }
 
-    /**
-     * Determines the piece which was clicked to operate on.
-     *
-     * @param point the location to lock on to
-     */
     private void lockOntoPiece(Point point) {
         final Piece toMove = Chess.getBoard(point);
         if (toMove != null && toMove.isWhite() == isWhiteTurn) {
             moving = toMove;
             from = point;
-            letUserKnowLegalMoves();
+            highlightLegalMoves();
             return;
         }
         moving = null;
         from = null;
     }
 
-    /**
-     * Creates marks on the board letting the user know where the piece can be moved.
-     */
-    private void letUserKnowLegalMoves() {
+    private void highlightLegalMoves() {
         final Color darkGreen = new Color(0, 100, 40);
         final Color lightGreen = new Color(0, 140, 50);
         for (int i = 0; i < Chess.BOARD_SIZE; i++) {
@@ -134,7 +113,7 @@ final class GameState {
         if (enPassant != null) {
             final boolean canCaptureEnPassant = from.y == enPassant.y + 1
                     && Math.abs(from.x - enPassant.x) == 1;
-            if (canCaptureEnPassant && isEnPassantLegal(enPassant)) {
+            if (canCaptureEnPassant && canPerformEnPassant(enPassant)) {
                 final Color usedColor = ((enPassant.y + enPassant.x) % 2 == 0 ^ !isWhiteTurn) ? lightGreen : darkGreen;
                 chess.drawTileBackgroundGUI(usedColor, enPassant.x, enPassant.y);
             }
@@ -142,33 +121,28 @@ final class GameState {
         chess.drawAllPiecesGUI();
     }
 
-    /**
-     * Determines if the move to make when the king is in check is legal.
-     *
-     * @param to where to move the king to
-     */
-    private void doMoveInCheck(Point to) {
+    private void doMoveInCheckIfLegal(Point to) {
         if (moving.isActionLegal(from, to)) {
-            checkEnPassant(to);
-            move(moving, from, to);
-            final Point location = locateKing(isWhiteTurn);
+            recordEnPassantHistory(to);
+            movePiece(moving, from, to);
+            final Point location = locateAlliedKing(isWhiteTurn);
             final King king = new King(isWhiteTurn);
             if (!king.isKingInCheck(location)) {
                 isWhiteTurn = !isWhiteTurn;
                 chess.flipBoard();
-                checkEndgame();
+                checkIfGameOver();
                 isInCheck = false;
             } else {
-                move(moving, to, from);
+                movePiece(moving, to, from);
             }
         }
     }
 
     /**
-     * Moves the piece. If it is a pawn moving into a promotion square, ask the user what to promote the pawn to and
-     * promote the pawn based on user input.
+     * Moves the piece. If it is a pawn moving into a promotion square, ask the
+     * user what to promote the pawn to and promote the pawn based on user input.
      *
-     * @param to where to move to
+     * @throws IllegalStateException if somehow the user ignored piece promotion
      */
     private void doMove(Point to) {
         if (to.y == 0 && moving instanceof Pawn) {
@@ -181,7 +155,7 @@ final class GameState {
             };
             int promotion = -1;
             while (promotion < 0) {
-                promotion = customText(text, options);
+                promotion = displayDialogText(text, options);
             }
             final Piece piece;
             switch (promotion) {
@@ -200,48 +174,37 @@ final class GameState {
                 default:
                     throw new IllegalStateException("Pawn promotion is mandatory.");
             }
-            move(piece, from, to);
+            movePiece(piece, from, to);
         } else {
-            move(moving, from, to);
+            movePiece(moving, from, to);
         }
         isWhiteTurn = !isWhiteTurn;
         chess.flipBoard();
-        checkEndgame();
+        checkIfGameOver();
     }
 
-    /**
-     * Determines if en passant may be used.
-     *
-     * @param to where to move the piece to
-     * @return true if en passant is legal
-     */
-    private boolean isEnPassantLegal(Point to) {
+    private boolean canPerformEnPassant(Point to) {
         final Point squareAboveEnemy = new Point(to.x, to.y + 1);
         return to.equals(enPassant) && moving instanceof Pawn
                 && moving.isWhite() != Chess.getBoard(squareAboveEnemy).isWhite();
     }
 
     /**
-     * Performs en passant. En passant is a move which lets a pawn capture a pawn which just moved two squares as if it
-     * only moved one square immediately after it happens.
+     * En passant is a move which lets a pawn capture a pawn which just moved
+     * two squares as if it only moved one square immediately after it happens.
      */
     private void doEnPassant() {
         final Point squareAboveEnemy = new Point(enPassant.x, enPassant.y + 1);
-        move(moving, from, enPassant);
+        movePiece(moving, from, enPassant);
         Chess.setBoard(squareAboveEnemy, null);
         enPassant = null;
         enPassantHistory.add(null);
         isWhiteTurn = !isWhiteTurn;
         chess.flipBoard();
-        checkEndgame();
+        checkIfGameOver();
     }
 
-    /**
-     * Keeps a record that en passant may be used at this location.
-     *
-     * @param to location to move to
-     */
-    private void checkEnPassant(Point to) {
+    private void recordEnPassantHistory(Point to) {
         if (moving instanceof Pawn && from.y - to.y == 2) {
             enPassant = new Point(to.x, to.y - 2);
         } else {
@@ -251,55 +214,35 @@ final class GameState {
     }
 
     /**
-     * Checks if the game is over. It may be over by checkmate or by draw.
-     * <p> There are 4 types of draws:
+     * The game may be over by checkmate or by draw. There are 4 types of draws:
      * <p> 1. Stalemate
      * <p> 2. 50 moves without pawn move or piece capture
      * <p> 3. Board repeated 3 times
      * <p> 4. Insufficient mating material
      */
-    private void checkEndgame() {
-        final Point location = locateKing(isWhiteTurn);
+    private void checkIfGameOver() {
+        final Point location = locateAlliedKing(isWhiteTurn);
         final King king = new King(isWhiteTurn);
-        if (isCheckmate(king, location)) {
+        if (isGameOverDueToCheckmate(king, location)) {
             final String text = Chess.resource.getString(isWhiteTurn ? "blackWins" : "whiteWins");
-            finishGame(text);
-        } else if (isStalemate(king, location)) {
+            endGameWithNotification(text);
+        } else if (isGameOverDueToStalemate(king, location)) {
             final String text = Chess.resource.getString("stalemate");
-            finishGame(text);
+            endGameWithNotification(text);
         }
-        otherDraw();
-        warnIfCheck(king, location);
+        endGameIfNonStalemateDraw();
+        warnIfKingInCheck(king, location);
     }
 
-    /**
-     * Determines if the game is over by checkmate.
-     *
-     * @param king  the king
-     * @param point the location of the king
-     * @return true if the game is over by checkmate
-     */
-    private boolean isCheckmate(King king, Point point) {
+    private boolean isGameOverDueToCheckmate(King king, Point point) {
         return king.isKingInCheck(point) && isMoveImpossible(king, point);
     }
 
-    /**
-     * Determines if the game is over by stalemate.
-     *
-     * @param king  the king
-     * @param point the location of the king
-     * @return true if the game is over by stalemate
-     */
-    private boolean isStalemate(King king, Point point) {
+    private boolean isGameOverDueToStalemate(King king, Point point) {
         return !king.isKingInCheck(point) && isMoveImpossible(king, point);
     }
 
     /**
-     * Determines if any move can be done which results in king not being in check.
-     *
-     * @param king  the king
-     * @param point the location of the king
-     * @return true if any move can be done which results in king not being in check
      * @throws IllegalStateException if king is not at the specified area
      */
     private boolean isMoveImpossible(King king, Point point) {
@@ -317,7 +260,7 @@ final class GameState {
                             final Piece save = Chess.getBoard(end);
                             if (me.isActionLegal(start, end)) {
                                 rawMove(me, start, end);
-                                final Point kingLocation = locateKing(isWhiteTurn);
+                                final Point kingLocation = locateAlliedKing(isWhiteTurn);
                                 final boolean isNotInCheck = !king.isKingInCheck(kingLocation);
                                 rawMove(me, end, start);
                                 Chess.setBoard(end, save);
@@ -333,13 +276,10 @@ final class GameState {
         return true;
     }
 
-    /**
-     * Determines if there is a non-stalemate draw.
-     */
-    private void otherDraw() {
-        determineIfTooManyMoves();
-        determineIfTooManyBoardRepetitions();
-        determineIfInsufficientMatingMaterial();
+    private void endGameIfNonStalemateDraw() {
+        endGameIfTooManyMoves();
+        endGameIfTooManyBoardRepetitions();
+        endGameIfInsufficientMatingMaterial();
     }
 
     /**
@@ -347,13 +287,13 @@ final class GameState {
      *
      * @throws IllegalStateException if somehow went over the draw counter
      */
-    private void determineIfTooManyMoves() {
+    private void endGameIfTooManyMoves() {
         final int MAX_MOVE_PER_SIDE = 50;
         final int MAX_UNPRODUCTIVE_MOVES = 2 * MAX_MOVE_PER_SIDE;
         if (drawCounter == MAX_UNPRODUCTIVE_MOVES) {
             final String text = Chess.resource.getString("draw") + ' '
                     + MAX_MOVE_PER_SIDE + ' ' + Chess.resource.getString("noCapture");
-            finishGame(text);
+            endGameWithNotification(text);
         } else if (drawCounter > MAX_UNPRODUCTIVE_MOVES) {
             throw new IllegalStateException("drawCounter > " + MAX_UNPRODUCTIVE_MOVES);
         }
@@ -362,16 +302,14 @@ final class GameState {
     /**
      * Draw if board repeated 3 times.
      */
-    private void determineIfTooManyBoardRepetitions() {
+    private void endGameIfTooManyBoardRepetitions() {
         if (isTooManyBoardRepetitions()) {
             final String text = Chess.resource.getString("boardRepeat");
-            finishGame(text);
+            endGameWithNotification(text);
         }
     }
 
     /**
-     * Determines if the board has repeated 3 times.
-     *
      * @return true if the board has repeated 3 times
      * @throws IllegalStateException if castle or en passant history size is invalid
      */
@@ -388,7 +326,7 @@ final class GameState {
         for (int i = 0; i < historySize; i++) {
             int count = 0;
             for (int j = 0; j < historySize; j++) {
-                if (isSameBoard(boardHistory.get(i), boardHistory.get(j))
+                if (areBoardEqual(boardHistory.get(i), boardHistory.get(j))
                         && canCastleHistory.get(i).equals(canCastleHistory.get(j))
                         && ((enPassantHistory.get(i) == null && enPassantHistory.get(j) == null)
                         || (enPassantHistory.get(i) != null && enPassantHistory.get(j) != null
@@ -406,14 +344,7 @@ final class GameState {
         return false;
     }
 
-    /**
-     * Determines if two specified boards are the same.
-     *
-     * @param boardOne the first board
-     * @param boardTwo the second board
-     * @return true if two boards are the same
-     */
-    private boolean isSameBoard(Piece[][] boardOne, Piece[][] boardTwo) {
+    private boolean areBoardEqual(Piece[][] boardOne, Piece[][] boardTwo) {
         for (int i = 0; i < Chess.BOARD_SIZE; i++) {
             for (int j = 0; j < Chess.BOARD_SIZE; j++) {
                 if (boardOne[i][j] != boardTwo[i][j]) {
@@ -425,24 +356,18 @@ final class GameState {
     }
 
     /**
-     * Draw if insufficient mating material. Mating material is any pieces which could force a checkmate.
+     * Mating material is any pieces which could force a checkmate.
      */
-    private void determineIfInsufficientMatingMaterial() {
+    private void endGameIfInsufficientMatingMaterial() {
         final List<Piece> ally = new ArrayList<>();
         final List<Piece> enemy = new ArrayList<>();
         findPieces(ally, enemy);
-        if (isInsufficientMating(ally, enemy)) {
+        if (isInsufficientMatingMaterial(ally, enemy)) {
             final String text = Chess.resource.getString("insufficientPieces");
-            finishGame(text);
+            endGameWithNotification(text);
         }
     }
 
-    /**
-     * Finds pieces on the board.
-     *
-     * @param ally  the ally pieces
-     * @param enemy the enemy pieces
-     */
     private void findPieces(List<Piece> ally, List<Piece> enemy) {
         for (int i = 0; i < Chess.BOARD_SIZE; i++) {
             for (int j = 0; j < Chess.BOARD_SIZE; j++) {
@@ -460,13 +385,10 @@ final class GameState {
     }
 
     /**
-     * Determines if insufficient mating material.
-     *
-     * @param ally  pieces allied with the King not including the King
-     * @param enemy pieces enemy to the King not including the King
-     * @return is lone King against: lone King, or King and Knight, or King and Bishop, or King and two Knights
+     * @return is lone King against:
+     * lone King, or King and Knight, or King and Bishop, or King and two Knights
      */
-    private boolean isInsufficientMating(List<Piece> ally, List<Piece> enemy) {
+    private boolean isInsufficientMatingMaterial(List<Piece> ally, List<Piece> enemy) {
         if (ally.size() != 0 && enemy.size() != 0) {
             return false;
         }
@@ -476,115 +398,69 @@ final class GameState {
                 || (group.size() == 2 && group.get(0) instanceof Knight && group.get(1) instanceof Knight);
     }
 
-    /**
-     * Gives a user a message and terminates the program.
-     *
-     * @param text the text to display to the user
-     */
-    private void finishGame(String text) {
+    private void endGameWithNotification(String text) {
         final String[] options = {Chess.resource.getString("acknowledge")};
-        customText(text, options);
+        displayDialogText(text, options);
         System.exit(0);
     }
 
-    /**
-     * Warns the user if the king is in check.
-     *
-     * @param king     the king which is in check
-     * @param location the location of the king in check
-     */
-    private void warnIfCheck(King king, Point location) {
+    private void warnIfKingInCheck(King king, Point location) {
         if (king.isKingInCheck(location)) {
             isInCheck = true;
             final String text = Chess.resource.getString("inCheck");
             final String[] options = {Chess.resource.getString("acknowledge")};
-            customText(text, options);
+            displayDialogText(text, options);
         }
     }
 
-    /**
-     * Determines if the king can castle, and if so, castle.
-     *
-     * @param to the location to move to
-     * @return true if the king can castle
-     */
     private boolean castleIfPossible(Point to) {
         if (to.y != Chess.BOARD_SIZE - 1) {
             return false;
         }
         if (to.x == 0 && canQueenSideCastle()) {
-            moveCastle(new Point(4, 7), new Point(2, 7));
-            moveCastle(new Point(0, 7), new Point(3, 7));
+            performCastling(new Point(4, 7), new Point(2, 7));
+            performCastling(new Point(0, 7), new Point(3, 7));
             return true;
         } else if (to.x == 7 && canKingSideCastle()) {
-            moveCastle(new Point(4, 7), new Point(6, 7));
-            moveCastle(new Point(7, 7), new Point(5, 7));
+            performCastling(new Point(4, 7), new Point(6, 7));
+            performCastling(new Point(7, 7), new Point(5, 7));
             return true;
         }
         return false;
     }
 
-    /**
-     * Determines if can queen side castle.
-     *
-     * @return true if queen side castle is legal
-     */
     private boolean canQueenSideCastle() {
         final King king = new King(isWhiteTurn);
         final boolean isLockedOnKing = from.x == 4 && from.y == 7;
-        final boolean isClearPath = hasMoved(Chess.getBoard(new Point(0, 7)))
+        final boolean isClearPath = hasPieceMoved(Chess.getBoard(new Point(0, 7)))
                 && Chess.getBoard(new Point(1, 7)) == null && Chess.getBoard(new Point(2, 7)) == null
-                && Chess.getBoard(new Point(3, 7)) == null && hasMoved(Chess.getBoard(new Point(4, 7)));
+                && Chess.getBoard(new Point(3, 7)) == null && hasPieceMoved(Chess.getBoard(new Point(4, 7)));
         final boolean isNotPassingThroughCheck = !king.isKingInCheck(new Point(4, 7))
                 && !king.isKingInCheck(new Point(3, 7)) && !king.isKingInCheck(new Point(2, 7));
         return isLockedOnKing && isClearPath && isNotPassingThroughCheck;
     }
 
-    /**
-     * Determines if can king side castle.
-     *
-     * @return true if king side castle is legal
-     */
     private boolean canKingSideCastle() {
         final King king = new King(isWhiteTurn);
         final boolean isLockedOnKing = from.x == 4 && from.y == 7;
-        final boolean isClearPath = hasMoved(Chess.getBoard(new Point(4, 7))) && Chess.getBoard(new Point(5, 7)) == null
-                && Chess.getBoard(new Point(6, 7)) == null && hasMoved(Chess.getBoard(new Point(7, 7)));
+        final boolean isClearPath = hasPieceMoved(Chess.getBoard(new Point(4, 7))) && Chess.getBoard(new Point(5, 7)) == null
+                && Chess.getBoard(new Point(6, 7)) == null && hasPieceMoved(Chess.getBoard(new Point(7, 7)));
         final boolean isNotPassingThroughCheck = !king.isKingInCheck(new Point(4, 7))
                 && !king.isKingInCheck(new Point(5, 7)) && !king.isKingInCheck(new Point(6, 7));
         return isLockedOnKing && isClearPath && isNotPassingThroughCheck;
     }
 
-    /**
-     * Determines if the piece has moved.
-     *
-     * @param me the piece
-     * @return true if the piece has moved
-     */
-    private boolean hasMoved(Piece me) {
+    private boolean hasPieceMoved(Piece me) {
         return me != null && !me.hasMoved();
     }
 
-    /**
-     * Moves the piece when castling.
-     *
-     * @param from location to move from
-     * @param to   location to move to
-     */
-    private void moveCastle(Point from, Point to) {
+    private void performCastling(Point from, Point to) {
         Chess.setBoard(to, Chess.getBoard(from));
         Chess.setBoard(from, null);
         Chess.getBoard(to).setMove();
     }
 
-    /**
-     * Moves the piece.
-     *
-     * @param me    the piece to move
-     * @param start the location to move from
-     * @param end   the location to move to
-     */
-    private void move(Piece me, Point start, Point end) {
+    private void movePiece(Piece me, Point start, Point end) {
         if (Chess.getBoard(end) != null || me instanceof Pawn) {
             drawCounter = 0;
             boardHistory.clear();
@@ -600,7 +476,7 @@ final class GameState {
                 }
             }
             boardHistory.add(boardCopy);
-            final Point kingLocation = locateKing(isWhiteTurn);
+            final Point kingLocation = locateAlliedKing(isWhiteTurn);
             canCastleHistory.add(Chess.getBoard(kingLocation).hasMoved());
         }
         rawMove(me, start, end);
@@ -608,26 +484,15 @@ final class GameState {
     }
 
     /**
-     * Moves the piece without setting the piece to moved state. Used when checking the board and not actually moving
-     * pieces on it.
-     *
-     * @param me    the piece to move
-     * @param start the location to move from
-     * @param end   the location to move to
+     * Moves the piece without setting the piece to moved state. Used
+     * when checking the board and not actually moving pieces on it.
      */
     private void rawMove(Piece me, Point start, Point end) {
         Chess.setBoard(start, null);
         Chess.setBoard(end, me);
     }
 
-    /**
-     * Displays text to the user using a dialog box.
-     *
-     * @param text    what to display
-     * @param options the options the user can click
-     * @return the option the user picked
-     */
-    private int customText(String text, String[] options) {
+    private int displayDialogText(String text, String[] options) {
         return JOptionPane.showOptionDialog(null, text, Chess.GAME_TITLE, JOptionPane.DEFAULT_OPTION,
                 JOptionPane.PLAIN_MESSAGE, null, options, options[0]);
     }

--- a/src/chess/King.java
+++ b/src/chess/King.java
@@ -25,7 +25,7 @@ final class King extends Piece {
                 {0, 1, 1, 1, 1, 0},
                 {0, 1, 1, 1, 1, 0}
         };
-        getColor(pixels);
+        setPieceImage(pixels);
     }
 
     @Override
@@ -37,7 +37,7 @@ final class King extends Piece {
     boolean isActionLegal(Point start, Point end) {
         return Math.abs(end.x - start.x) + Math.abs(end.y - start.y) != 0
                 && Math.abs(end.x - start.x) <= 1 && Math.abs(end.y - start.y) <= 1
-                && canMoveOnto(end) && isNoAdjacentKing(end) && !isCheck(end);
+                && canMoveToLocation(end) && isNoAdjacentKing(end) && !isCheck(end);
     }
 
     /**

--- a/src/chess/King.java
+++ b/src/chess/King.java
@@ -37,28 +37,15 @@ final class King extends Piece {
     boolean isActionLegal(Point start, Point end) {
         return Math.abs(end.x - start.x) + Math.abs(end.y - start.y) != 0
                 && Math.abs(end.x - start.x) <= 1 && Math.abs(end.y - start.y) <= 1
-                && canMoveToLocation(end) && isNoAdjacentKing(end) && !isCheck(end);
+                && canMoveToLocation(end) && isNoAdjacentKing(end) && !isKingInCheck(end);
     }
 
-    /**
-     * Determines if there is no adjacent King.
-     *
-     * @param me the position to check for adjacent king
-     * @return true if there is no adjacent king
-     */
     private boolean isNoAdjacentKing(Point me) {
         return isKingNotAt(me.x - 1, me.y - 1) && isKingNotAt(me.x, me.y - 1) && isKingNotAt(me.x + 1, me.y - 1)
                 && isKingNotAt(me.x - 1, me.y) && isKingNotAt(me.x + 1, me.y)
                 && isKingNotAt(me.x - 1, me.y + 1) && isKingNotAt(me.x, me.y + 1) && isKingNotAt(me.x + 1, me.y + 1);
     }
 
-    /**
-     * Determines if there is no King at the specified location.
-     *
-     * @param x the x-coordinate
-     * @param y the y-coordinate
-     * @return true if there is no King at the specified location
-     */
     private boolean isKingNotAt(int x, int y) {
         if (x < 0 || x >= Chess.BOARD_SIZE || y < 0 || y >= Chess.BOARD_SIZE) {
             return true;
@@ -69,29 +56,15 @@ final class King extends Piece {
         return !isEnemyKing;
     }
 
-    /**
-     * Determines if the king is in check.
-     *
-     * @param point the location to check
-     * @return true if the king is in check
-     */
-    boolean isCheck(Point point) {
-        return isCheckDiagonal(point, -1, -1) || isCheckDiagonal(point, -1, 1)
-                || isCheckDiagonal(point, 1, -1) || isCheckDiagonal(point, 1, 1)
-                || isCheckStraight(point, 0, -1) || isCheckStraight(point, 0, 1)
-                || isCheckStraight(point, -1, 0) || isCheckStraight(point, 1, 0)
-                || isCheckPawn(point) || isCheckKnight(point);
+    boolean isKingInCheck(Point point) {
+        return isCheckFromDiagonalLine(point, -1, -1) || isCheckFromDiagonalLine(point, -1, 1)
+                || isCheckFromDiagonalLine(point, 1, -1) || isCheckFromDiagonalLine(point, 1, 1)
+                || isCheckFromStraightLine(point, 0, -1) || isCheckFromStraightLine(point, 0, 1)
+                || isCheckFromStraightLine(point, -1, 0) || isCheckFromStraightLine(point, 1, 0)
+                || isCheckDueToPawn(point) || isCheckDueToKnight(point);
     }
 
-    /**
-     * Determines if the king is in check due to a diagonal opponent, such as a bishop or a queen.
-     *
-     * @param point  the location to check
-     * @param xScale the side to check on for the x-coordinate
-     * @param yScale the side to check on for the y-coordinate
-     * @return true if the king is in check due to a diagonal opponent
-     */
-    private boolean isCheckDiagonal(Point point, int xScale, int yScale) {
+    private boolean isCheckFromDiagonalLine(Point point, int xScale, int yScale) {
         final Point mutatingPoint = new Point(point);
         mutatingPoint.x += xScale;
         mutatingPoint.y += yScale;
@@ -109,15 +82,7 @@ final class King extends Piece {
         return false;
     }
 
-    /**
-     * Determines if the king is in check due to a straight opponent, such as a rook or a queen.
-     *
-     * @param point  the location to check
-     * @param xScale the side to check on for the x-coordinate
-     * @param yScale the side to check on for the y-coordinate
-     * @return true if the king is in check due to a straight opponent
-     */
-    private boolean isCheckStraight(Point point, int xScale, int yScale) {
+    private boolean isCheckFromStraightLine(Point point, int xScale, int yScale) {
         final Point mutatingPoint = new Point(point);
         mutatingPoint.x += xScale;
         mutatingPoint.y += yScale;
@@ -135,24 +100,11 @@ final class King extends Piece {
         return false;
     }
 
-    /**
-     * Determines if the king is in check due to a pawn.
-     *
-     * @param point the location to check
-     * @return true if the king is in check due to a pawn
-     */
-    private boolean isCheckPawn(Point point) {
-        return isEnemyPawn(point.x - 1, point.y - 1) || isEnemyPawn(point.x + 1, point.y - 1);
+    private boolean isCheckDueToPawn(Point point) {
+        return isEnemyPawnAt(point.x - 1, point.y - 1) || isEnemyPawnAt(point.x + 1, point.y - 1);
     }
 
-    /**
-     * Determines if the king is in check due to one side a pawn can capture from.
-     *
-     * @param x the x-coordinate
-     * @param y the y-coordinate
-     * @return true if the king is in check due to one side a pawn can capture from
-     */
-    private boolean isEnemyPawn(int x, int y) {
+    private boolean isEnemyPawnAt(int x, int y) {
         if (!isInGridBounds(x, y)) {
             return false;
         }
@@ -161,27 +113,14 @@ final class King extends Piece {
         return me instanceof Pawn && me.isWhite() != isWhite;
     }
 
-    /**
-     * Determines if the king is in check due to a knight.
-     *
-     * @param point the location to check
-     * @return true if the king is in check due to a knight
-     */
-    private boolean isCheckKnight(Point point) {
-        return (isEnemyKnight(point.x - 2, point.y - 1)) || (isEnemyKnight(point.x - 1, point.y - 2))
-                || (isEnemyKnight(point.x - 2, point.y + 1)) || (isEnemyKnight(point.x - 1, point.y + 2))
-                || (isEnemyKnight(point.x + 2, point.y - 1)) || (isEnemyKnight(point.x + 1, point.y - 2))
-                || (isEnemyKnight(point.x + 2, point.y + 1)) || (isEnemyKnight(point.x + 1, point.y + 2));
+    private boolean isCheckDueToKnight(Point point) {
+        return (isEnemyKnightAt(point.x - 2, point.y - 1)) || (isEnemyKnightAt(point.x - 1, point.y - 2))
+                || (isEnemyKnightAt(point.x - 2, point.y + 1)) || (isEnemyKnightAt(point.x - 1, point.y + 2))
+                || (isEnemyKnightAt(point.x + 2, point.y - 1)) || (isEnemyKnightAt(point.x + 1, point.y - 2))
+                || (isEnemyKnightAt(point.x + 2, point.y + 1)) || (isEnemyKnightAt(point.x + 1, point.y + 2));
     }
 
-    /**
-     * Determines if the king is in check due to one spot a knight can capture from.
-     *
-     * @param x the x-coordinate
-     * @param y the y-coordinate
-     * @return true if the king is in check due to one spot a knight can capture from
-     */
-    private boolean isEnemyKnight(int x, int y) {
+    private boolean isEnemyKnightAt(int x, int y) {
         if (!isInGridBounds(x, y)) {
             return false;
         }
@@ -190,23 +129,10 @@ final class King extends Piece {
         return me instanceof Knight && me.isWhite() != isWhite;
     }
 
-    /**
-     * Determines if the point is in bounds.
-     *
-     * @param p the point
-     * @return true if the point is in bounds
-     */
     private boolean isInGridBounds(Point p) {
         return isInGridBounds(p.x, p.y);
     }
 
-    /**
-     * Determines if the coordinates are in bounds.
-     *
-     * @param x the x-coordinate
-     * @param y the y-coordinate
-     * @return true if the coordinates are in bounds
-     */
     private boolean isInGridBounds(int x, int y) {
         return x >= 0 && y >= 0 && x < Chess.BOARD_SIZE && y < Chess.BOARD_SIZE;
     }

--- a/src/chess/Knight.java
+++ b/src/chess/Knight.java
@@ -21,7 +21,7 @@ final class Knight extends Piece {
                 {0, 1, 1, 1, 1, 1},
                 {1, 1, 1, 1, 1, 1}
         };
-        getColor(pixels);
+        setPieceImage(pixels);
     }
 
     @Override
@@ -33,6 +33,6 @@ final class Knight extends Piece {
     boolean isActionLegal(Point start, Point end) {
         final boolean isMoveL = (Math.abs(end.x - start.x) == 2 && Math.abs(end.y - start.y) == 1)
                 || (Math.abs(end.x - start.x) == 1 && Math.abs(end.y - start.y) == 2);
-        return isMoveL && canMoveOnto(end) && wouldNotPutKingIntoCheck(start, end);
+        return isMoveL && canMoveToLocation(end) && wouldNotPutAlliedKingIntoCheck(start, end);
     }
 }

--- a/src/chess/Pawn.java
+++ b/src/chess/Pawn.java
@@ -19,7 +19,7 @@ final class Pawn extends Piece {
                 {0, 1, 1, 1, 1, 0},
                 {1, 1, 1, 1, 1, 1}
         };
-        getColor(pixels);
+        setPieceImage(pixels);
     }
 
     @Override
@@ -37,6 +37,6 @@ final class Pawn extends Piece {
         final boolean isCapture = Chess.getBoard(end) != null
                 && Chess.getBoard(end).isWhite() != isWhite
                 && end.y == start.y - 1 && Math.abs(end.x - start.x) == 1;
-        return (isForwardAllowed || isCapture) && wouldNotPutKingIntoCheck(start, end);
+        return (isForwardAllowed || isCapture) && wouldNotPutAlliedKingIntoCheck(start, end);
     }
 }

--- a/src/chess/Piece.java
+++ b/src/chess/Piece.java
@@ -11,65 +11,30 @@ abstract class Piece {
     private final Color[][] image = new Color[PIECE_SIZE][PIECE_SIZE];
     private boolean hasMoved;
 
-    /**
-     * Determines whether the piece is white or not.
-     *
-     * @return true if the piece is white
-     */
     abstract boolean isWhite();
 
-    /**
-     * Determines if the action is legal.
-     *
-     * @param start the original position
-     * @param end   the final position
-     * @return true if the action is legal
-     */
     abstract boolean isActionLegal(Point start, Point end);
 
-    /**
-     * Determines if the piece has moved.
-     *
-     * @return true if the piece has moved
-     */
     final boolean hasMoved() {
         return hasMoved;
     }
 
-    /**
-     * Sets the piece to be moved.
-     */
     final void setMove() {
         hasMoved = true;
     }
 
-    /**
-     * Gets the color representation of the piece.
-     *
-     * @return the color representation of the piece
-     */
-    final Color[][] getImage() {
+    final Color[][] getPieceImage() {
         return image;
     }
 
-    /**
-     * Determines if a piece can move onto a grid location.
-     *
-     * @param point location to check
-     * @return true if the piece can move onto the location
-     */
-    final boolean canMoveOnto(Point point) {
+    final boolean canMoveToLocation(Point point) {
         return Chess.getBoard(point) == null || Chess.getBoard(point).isWhite() != isWhite();
     }
 
     /**
-     * Sets the color of each piece displayed on the board based on which squares contain pieces and if they are white
-     * or black.
-     *
-     * @param pixels the pixels on the board
      * @throws IllegalStateException if invalid pixel value on the pixel board
      */
-    final void getColor(int[][] pixels) {
+    final void setPieceImage(int[][] pixels) {
         for (int i = 0; i < pixels.length; i++) {
             for (int j = 0; j < pixels.length; j++) {
                 final int pixel = pixels[i][j];
@@ -86,14 +51,7 @@ abstract class Piece {
         }
     }
 
-    /**
-     * Determines if moving the piece would put the allied king in check.
-     *
-     * @param start the start position
-     * @param end   the end position
-     * @return true if moving the piece would put the king in check
-     */
-    final boolean wouldNotPutKingIntoCheck(Point start, Point end) {
+    final boolean wouldNotPutAlliedKingIntoCheck(Point start, Point end) {
         final Piece backup = Chess.getBoard(end);
         Chess.setBoard(end, this);
         Chess.setBoard(start, null);

--- a/src/chess/Piece.java
+++ b/src/chess/Piece.java
@@ -55,7 +55,7 @@ abstract class Piece {
         final Piece backup = Chess.getBoard(end);
         Chess.setBoard(end, this);
         Chess.setBoard(start, null);
-        final Point kingPoint = GameState.locateKing(isWhite());
+        final Point kingPoint = GameState.locateAlliedKing(isWhite());
         final King king = (King) Chess.getBoard(kingPoint);
         final boolean isAllowed = !king.isKingInCheck(kingPoint);
         Chess.setBoard(start, this);

--- a/src/chess/Piece.java
+++ b/src/chess/Piece.java
@@ -57,7 +57,7 @@ abstract class Piece {
         Chess.setBoard(start, null);
         final Point kingPoint = GameState.locateKing(isWhite());
         final King king = (King) Chess.getBoard(kingPoint);
-        final boolean isAllowed = !king.isCheck(kingPoint);
+        final boolean isAllowed = !king.isKingInCheck(kingPoint);
         Chess.setBoard(start, this);
         Chess.setBoard(end, backup);
         return isAllowed;

--- a/src/chess/Queen.java
+++ b/src/chess/Queen.java
@@ -21,7 +21,7 @@ final class Queen extends Piece {
                 {0, 1, 1, 1, 1, 0},
                 {1, 1, 1, 1, 1, 1}
         };
-        getColor(pixels);
+        setPieceImage(pixels);
     }
 
     @Override
@@ -33,9 +33,9 @@ final class Queen extends Piece {
     boolean isActionLegal(Point start, Point end) {
         final Bishop bishop = new Bishop(isWhite);
         if (bishop.isEachCoordinateDeltaSame(start, end)) {
-            return bishop.isBishopActionLegal(start, end) && wouldNotPutKingIntoCheck(start, end);
+            return bishop.isBishopActionLegal(start, end) && wouldNotPutAlliedKingIntoCheck(start, end);
         }
         final Rook rook = new Rook(isWhite);
-        return rook.isRookActionLegal(start, end) && wouldNotPutKingIntoCheck(start, end);
+        return rook.isRookActionLegal(start, end) && wouldNotPutAlliedKingIntoCheck(start, end);
     }
 }

--- a/src/chess/Queen.java
+++ b/src/chess/Queen.java
@@ -32,7 +32,7 @@ final class Queen extends Piece {
     @Override
     boolean isActionLegal(Point start, Point end) {
         final Bishop bishop = new Bishop(isWhite);
-        if (bishop.isEachCoordinateDeltaSame(start, end)) {
+        if (bishop.isDiagonalLine(start, end)) {
             return bishop.isBishopActionLegal(start, end) && wouldNotPutAlliedKingIntoCheck(start, end);
         }
         final Rook rook = new Rook(isWhite);

--- a/src/chess/Rook.java
+++ b/src/chess/Rook.java
@@ -33,13 +33,6 @@ final class Rook extends Piece {
         return isRookActionLegal(start, end) && wouldNotPutAlliedKingIntoCheck(start, end);
     }
 
-    /**
-     * Rook can capture enemy and can travel as long as nothing is in its way.
-     *
-     * @param start the original position
-     * @param end   the final position
-     * @return true if rook action is legal
-     */
     boolean isRookActionLegal(Point start, Point end) {
         if ((start.x == end.x && start.y == end.y) || (start.x != end.x && start.y != end.y)) {
             return false;

--- a/src/chess/Rook.java
+++ b/src/chess/Rook.java
@@ -20,7 +20,7 @@ final class Rook extends Piece {
                 {0, 1, 1, 1, 1, 0},
                 {1, 1, 1, 1, 1, 1}
         };
-        getColor(pixels);
+        setPieceImage(pixels);
     }
 
     @Override
@@ -30,7 +30,7 @@ final class Rook extends Piece {
 
     @Override
     boolean isActionLegal(Point start, Point end) {
-        return isRookActionLegal(start, end) && wouldNotPutKingIntoCheck(start, end);
+        return isRookActionLegal(start, end) && wouldNotPutAlliedKingIntoCheck(start, end);
     }
 
     /**
@@ -63,6 +63,6 @@ final class Rook extends Piece {
                 }
             }
         }
-        return canMoveOnto(end);
+        return canMoveToLocation(end);
     }
 }


### PR DESCRIPTION
Improve method names to make them self-documenting, and as a result, remove many documentation comments.